### PR TITLE
Fix dir name in readme

### DIFF
--- a/BIOS for LattePanda Alpha&Delta/Alpha m3-8100y/Alpha-8100y KR300/Alpha -8100y KR300 Auto-power-on BIOS/README.md
+++ b/BIOS for LattePanda Alpha&Delta/Alpha m3-8100y/Alpha-8100y KR300/Alpha -8100y KR300 Auto-power-on BIOS/README.md
@@ -1,7 +1,7 @@
 ## HOW TO REFLASH BIOS
 
 1. Format your USB drive to FAT32 and change the drive name to "WINPE";
-2. Copy all the files under **"CDJQ-BS-7-S70KR300-KF65A-101-J"** to root directory of your USB Drive.
+2. Copy all the files under **"BS-7-S70KR300-KF65A-101-J"** to root directory of your USB Drive.
  ![](https://www.lattepanda.com/wp-content/uploads/2020/06/Untitled.png)
 3. Plug the U-drive in USB host and boot the system; Press “ESC” and go into the BIOS setting page.
 4. Navigate to “Save & Exit”, choose "UEFI: Built-in EFI Shell" and press “Enter";


### PR DESCRIPTION
The first dirname to copy the contents of is wrong, it currently refers to a subdir, not the parent dir